### PR TITLE
Improve player feedback.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build: build_wheel build_image
 
 .PHONY: build_image
 build_image:
-	docker build --build-arg version=${version} --tag qwazzock:latest --tag qwazzock:${version} .
+	docker build --build-arg version=${version} --tag qwazzock:latest --tag qwazzock:${version} --network=host .
 
 .PHONY: build_wheel
 build_wheel: test clean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qwazzock"
-version = "0.4.2"
+version = "0.5.0"
 description = "Qwazzock quiz app."
 authors = ["Dave Randall <19395688+daveygit2050@users.noreply.github.com>"]
 

--- a/qwazzock/server.py
+++ b/qwazzock/server.py
@@ -21,16 +21,6 @@ def get_socketio_and_app(game):
 
     # Sockets
 
-    @socketio.on("buzz", namespace="/player_client_socket")
-    def player_client_socket_buzz_event(json):
-        app.logger.info(
-            f"Recevied buzz from {json['player_name']} of {json['team_name']}."
-        )
-        game.update_hotseat(
-            player_name=json["player_name"], team_name=json["team_name"]
-        )
-        update_clients()
-
     @socketio.on("connect", namespace="/host_client_socket")
     def host_client_socket_connect():
         update_clients()
@@ -54,6 +44,20 @@ def get_socketio_and_app(game):
     @socketio.on("wrong", namespace="/host_client_socket")
     def host_client_socket_wrong_event():
         game.wrong_answer()
+        update_clients()
+
+    @socketio.on("connect", namespace="/player_client_socket")
+    def player_client_socket_connect():
+        update_clients()
+
+    @socketio.on("buzz", namespace="/player_client_socket")
+    def player_client_socket_buzz_event(json):
+        app.logger.info(
+            f"Recevied buzz from {json['player_name']} of {json['team_name']}."
+        )
+        game.update_hotseat(
+            player_name=json["player_name"], team_name=json["team_name"]
+        )
         update_clients()
 
     # Helpers

--- a/qwazzock/static/css/common.css
+++ b/qwazzock/static/css/common.css
@@ -1,4 +1,12 @@
-.selectDisable {
+.qwa-buzzer {
+    width: 80vw;
+    height: 55vh;
+    margin: 4vh 10vw;
+    font-size: calc(10vw + 10vh);
+    cursor: pointer;
+}
+
+.qwa-select-disable {
     -webkit-user-select: none;
     -khtml-user-select: none;
     -moz-user-select: none;

--- a/qwazzock/static/js/player_client.js
+++ b/qwazzock/static/js/player_client.js
@@ -1,14 +1,28 @@
 $(document).ready(function () {
     var socket = io.connect('https://' + document.domain + ':' + location.port + '/player_client_socket');
     socket.on('player_client_data', function (msg) {
-        if (msg.player_in_hotseat != "Pending" || jQuery.inArray($("#team_name").val(), msg.locked_out_teams) !== -1) {
+        if (msg.player_in_hotseat == $("#player_name").val()) {
+            $("#feedback").html(msg.player_in_hotseat + ", you are in the hotseat!")
+            $("#buzzer").prop("disabled", true);
+        } else if (msg.player_in_hotseat != "Pending") {
+            $("#feedback").html(msg.player_in_hotseat + " (" + msg.team_in_hotseat + ") is in the hotseat.")
+            $("#buzzer").prop("disabled", true);
+        } else if (jQuery.inArray($("#team_name").val(), msg.locked_out_teams) !== -1) {
+            $("#feedback").html("Your team is locked out.")
             $("#buzzer").prop("disabled", true);
         } else {
+            $("#feedback").html("Fingers on buzzers!")
             $("#buzzer").prop("disabled", false);
         }
     });
     $("#buzzer").click(function () {
-        console.log("Buzzer buzzed via POST.");
-        socket.emit('buzz', { player_name: $("#player_name").val(), team_name: $("#team_name").val() })
+        if ($("#player_name").val().trim() == "") {
+            $("#feedback").html("Player name cannot be blank.")
+        } else if ($("#team_name").val().trim() == "") {
+            $("#feedback").html("Team name cannot be blank.")
+        } else {
+            console.log("Buzzer buzzed.");
+            socket.emit('buzz', { player_name: $("#player_name").val(), team_name: $("#team_name").val() })
+        }
     });
 });

--- a/qwazzock/templates/player_client.html
+++ b/qwazzock/templates/player_client.html
@@ -10,6 +10,7 @@
         <link rel="stylesheet" href="static/css/common.css">
     </head>
     <body>
+        <h3><div id="feedback" align=center style="margin:1vh 1vw;">Fingers on buzzers!</div></h3>
         <div class="mdl-textfield mdl-js-textfield" style="width:90vw;margin:1vh 5vw;font-size:xx-large;">
             <input class="mdl-textfield__input" type="text" id="player_name" style="font-size: xx-large;">
             <label class="mdl-textfield__label" for="player_name" style="font-size: xx-large;">Player Name</label>
@@ -19,7 +20,7 @@
             <label class="mdl-textfield__label" for="team_name" style="font-size: xx-large;">Team Name</label>
         </div>
         <div>
-            <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent selectDisable" id="buzzer" style="width:80vw;height:55vh;margin:4vh 10vw;font-size:calc(10vw + 10vh);">BUZZ</button>
+            <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent qwa-buzzer qwa-select-disable" id="buzzer">BUZZ</button>
         </div>
     </body>
 </html>

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -91,6 +91,14 @@ def test_host_client_socket_wrong_event_ok(socketio_test_client, mocker):
     assert len(mock_socketio_emit.mock_calls) == 4
 
 
+def test_player_client_socket_connect_ok(socketio_test_client, mocker):
+    mock_socketio_emit = mocker.patch("qwazzock.server.SocketIO.emit")
+    game = Game()
+    socketio_test_client_under_test = socketio_test_client(game)
+    socketio_test_client_under_test.connect(namespace="/player_client_socket")
+    assert len(mock_socketio_emit.mock_calls) == 2
+
+
 def test_player_client_socket_buzz_event_ok(socketio_test_client, mocker):
     mock_socketio_emit = mocker.patch("qwazzock.server.SocketIO.emit")
     game = Game()
@@ -101,4 +109,4 @@ def test_player_client_socket_buzz_event_ok(socketio_test_client, mocker):
         {"player_name": "foo-name", "team_name": "foo-team"},
         namespace="/player_client_socket",
     )
-    assert len(mock_socketio_emit.mock_calls) == 2
+    assert len(mock_socketio_emit.mock_calls) == 4


### PR DESCRIPTION
- Bumps version to `0.5.0`.
- Set host network on docker build to workaround issue building image on pi.
- Fixes bug where player screen would not update with game state on launch.
- Reorders methods in `Server` class.
- All custom classes in css are now prefixed with `qwa`.
- Hopefully fixes bug on some mobile devices which meant some buzz events were not being sent.
- Adds feedback to player screen so that they know who is in the hotseat or if they are locked out.
- Prevents players from buzzing if they have not entered a player name or team name.
- Moves styling for buzzer button into common.css.
- Adds/updates unit tests.