### PR TITLE
Allow iOS Safari users to buzz with one button tap.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qwazzock"
-version = "0.7.0"
+version = "0.7.1"
 description = "Qwazzock quiz app."
 authors = ["Dave Randall <19395688+daveygit2050@users.noreply.github.com>"]
 

--- a/qwazzock/static/js/player_client.js
+++ b/qwazzock/static/js/player_client.js
@@ -15,7 +15,7 @@ $(document).ready(function () {
             $("#buzzer").prop("disabled", false);
         }
     });
-    $("#buzzer").click(function () {
+    $("#buzzer").on('click touchstart hover', function () {
         if ($("#player_name").val().trim() == "") {
             $("#feedback").html("Player name cannot be blank.")
         } else if ($("#team_name").val().trim() == "") {


### PR DESCRIPTION
- Bumps version to `0.7.1`.
- Apparantly many iOS devices treat the first touch of the button as a hover, and the second as a click. This meant iOS users previously had to double tap in order for a buzz to register. Adding hover as a trigger doesn't seem to have any impact on PC users either.