### PR TITLE
Implement picture question type

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3.8
       args: [--config=./pyproject.toml]
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v1.9.0

--- a/README.md
+++ b/README.md
@@ -25,14 +25,37 @@ As a host, you can then navigate to the `/host` path (e.g. http://127.0.0.1:5000
 
 You can also use `reset` to wipe all data for the in progress game and start a new one.
 
+### Question Types
+
+There are two "question types" you can select, `standard` or `picture`.
+
+#### Standard
+
+This is the default question type. It allows you to ask any question and decide if the answer is right or wrong.
+
+#### Picture
+
+When this quesiton type is selected, all players are presnted with a randomly selected image from the `questions` folder in the content directory (see below) as their buzzer image. You will be presented with the name of the image they are seeing.
+
+The ordering of the images is random. Once you select `pass`, `right` or `wrong`, the next image in the list will be presented. This will continue until you change question type, or you run out of question images. If the latter occurs, the question type will automatically revery back to `standard`.
+
+Should you not provide a content directory, the content directory does not contain a `questions` folder, or the `questions` folder is empty, then the question type will automatically revert back to `standard`.
+
 ### Environment variables
 
 Behaviour of the application can be tweaked by setting the following environment variables:
 
 |Name|Options|Default|Description|
 |-|-|-|-|
+|`QWAZZOCK_CONTENT_PATH`|A valid absolute path.|Not set|If set, additional content is loaded into qwazzock from this directory.|
 |`QWAZZOCK_LOG_LEVEL`|`DEBUG`, `INFO`, `WARNING`, `ERROR`|`INFO`|Log application events at this level and above.|
 |`QWAZZOCK_SOCKETIO_DEBUG_MODE`|Any|Not set|If set, access logs from socketio will be output.|
+
+### Content Directory
+
+For a more interactive experience, you can load custom content into a "content directory" and provide this to qwazzock using the `QWAZZOCK_CONTENT_PATH` environment variable.
+
+Currently, the only supported custom content is images for use with the `picture` question type. These must be loaded into a `questions` folder within the content directory. The file name should be the answer as you wish it to appear to the host.
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qwazzock"
-version = "0.10.0"
+version = "0.11.0"
 description = "Qwazzock quiz app."
 authors = ["Dave Randall <19395688+daveygit2050@users.noreply.github.com>"]
 

--- a/qwazzock/__init__.py
+++ b/qwazzock/__init__.py
@@ -1,7 +1,7 @@
 import os
 
+from qwazzock.logs import logger  # noreorder
 from qwazzock.game import Game
-from qwazzock.logs import logger
 from qwazzock.server import get_socketio_and_app
 
 

--- a/qwazzock/__init__.py
+++ b/qwazzock/__init__.py
@@ -6,7 +6,9 @@ from qwazzock.server import get_socketio_and_app
 
 
 def run():
-    socketio, app = get_socketio_and_app(game=Game())
+    game = Game(content_path=os.getenv("QWAZZOCK_CONTENT_PATH"))
+    logger.info(f"Content path set to {game.content_path}.")
+    socketio, app = get_socketio_and_app(game=game)
     debug_mode = True if os.getenv("QWAZZOCK_SOCKETIO_DEBUG_MODE") else False
     socketio.run(app, debug=debug_mode, host="0.0.0.0")
 

--- a/qwazzock/static/js/host_client.js
+++ b/qwazzock/static/js/host_client.js
@@ -22,6 +22,15 @@ $(document).ready(function () {
             $("#right").prop("disabled", false);
             $("#wrong").prop("disabled", false);
         }
+        if (msg.question_type == "standard") {
+            $("#standard").prop("disabled", true);
+            $("#picture").prop("disabled", false);
+            $("#answer").html("")
+        } else {
+            $("#standard").prop("disabled", false);
+            $("#picture").prop("disabled", true);
+            $("#answer").html("Question Image: " + msg.selected_image)
+        }
     });
 
     $("#pass").click(function () {
@@ -37,6 +46,14 @@ $(document).ready(function () {
     });
     $("#wrong").click(function () {
         socket.emit('wrong');
+    });
+    $("#standard").click(function () {
+        console.log("Switching to standard question type.")
+        socket.emit('standard');
+    });
+    $("#picture").click(function () {
+        console.log("Switching to picture question type.")
+        socket.emit('picture');
     });
 
     var dialogButton = document.querySelector('#reset-button');

--- a/qwazzock/static/js/player_client.js
+++ b/qwazzock/static/js/player_client.js
@@ -14,6 +14,11 @@ $(document).ready(function () {
             $("#feedback").html("Fingers on buzzers!")
             $("#buzzer").prop("disabled", false);
         }
+        if (msg.question_type == "picture") {
+            $("#buzzer-image").prop("src", "static/questions/" + msg.selected_image);
+        } else {
+            $("#buzzer-image").prop("src", "static/images/buzzer.svg");
+        }
     });
     $("#buzzer").on('click touchstart hover', function () {
         if ($("#player_name").val().trim() == "") {

--- a/qwazzock/templates/host_client.html
+++ b/qwazzock/templates/host_client.html
@@ -8,6 +8,7 @@
     <h2>
         <div id="locked_out">Locked out: </div>
         <div id="scores">Scores: {}</div>
+        <div id="answer"></div>
     </h2>
     <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
         <input class="mdl-textfield__input" type="text" pattern="[0-9]+" id="score_value" value="1">
@@ -21,6 +22,11 @@
             style="height:5vh;width:10vw;margin-right:1vw;" disabled>Right</button>
         <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent" id="wrong"
             style="height:5vh;width:10vw;margin-right:1vw;" disabled>Wrong</button>
+        <div style="height:5vh;"></div>
+        <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent" id="standard"
+            style="height:5vh;width:10vw;margin-right:1vw;" disabled>Standard</button>
+        <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent" id="picture"
+            style="height:5vh;width:10vw;margin-right:1vw;">Picture</button>
         <div style="height:5vh;"></div>
         <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent" id="reset-button"
             style="height:5vh;width:10vw;margin-right:1vw;">Reset</button>

--- a/qwazzock/templates/player_client.html
+++ b/qwazzock/templates/player_client.html
@@ -11,7 +11,7 @@
     </div>
     <div>
         <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent qwa-buzzer qwa-select-disable" id="buzzer">
-            <img src="static/images/buzzer.svg" style="max-width:100%; max-height:100%;">
+            <img src="static/images/buzzer.svg" style="max-width:100%; max-height:100%;" id="buzzer-image">
         </button>
     </div>
 {% endblock %}

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -35,6 +35,40 @@ class TestGame:
         assert game.player_in_hotseat == "Pending"
         assert game.team_in_hotseat == "Pending"
 
+    def test_game_next_question_ok(self, mocker):
+        mocker.patch("qwazzock.Game.prepare_picture_round")
+        game = Game()
+        game.question_type = "picture"
+        game.selected_image_index = 1
+        game.question_images = ["foo.jpg", "bar.png", "blah.bmp"]
+        game.next_question()
+        assert game.selected_image_index == 2
+        assert game.selected_image == "blah.bmp"
+        assert game.question_type == "picture"
+
+    def test_game_next_question_no_more_images(self, mocker):
+        mock_prepare_picture_round = mocker.patch("qwazzock.Game.prepare_picture_round")
+        game = Game()
+        game.question_type = "picture"
+        game.selected_image_index = 2
+        game.question_images = ["foo.jpg", "bar.png", "blah.bmp"]
+        game.next_question()
+        assert game.question_type == "standard"
+        assert len(mock_prepare_picture_round.mock_calls) == 2
+
+    def test_game_prepare_picture_round_ok(self, mocker):
+        mock_os_listdir = mocker.patch("os.listdir")
+        mock_os_listdir.return_value = ["foo.jpg", "bar.png", "blah.bmp"]
+        game = Game(content_path="/foo-content-path")
+        assert "bar.png" in game.question_images
+        assert game.selected_image_index == 0
+
+    def test_game_prepare_picture_round_no_files(self, mocker):
+        mock_os_listdir = mocker.patch("os.listdir")
+        mock_os_listdir.return_value = []
+        game = Game(content_path="/foo-content-path")
+        assert game.selected_image_index is None
+
     def test_game_reset_ok(self):
         game = Game()
         game.player_in_hotseat = "Bob"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -48,6 +48,16 @@ def test_get_host_ok(socketio_test_client, game, mocker):
     )
 
 
+def test_get_question_image_ok(socketio_test_client, game, mocker):
+    mock_send_file = mocker.patch("qwazzock.server.send_file")
+    game.content_path = "/foo/content/path"
+    socketio_test_client_under_test = socketio_test_client(game)
+    socketio_test_client_under_test.app.test_client().get(
+        "/static/questions/bar-image.jpg"
+    )
+    mock_send_file.assert_called_once_with("/foo/content/path/questions/bar-image.jpg")
+
+
 def test_host_client_socket_connect_ok(socketio_test_client, mocker):
     mock_socketio_emit = mocker.patch("qwazzock.server.SocketIO.emit")
     game = Game()
@@ -63,6 +73,32 @@ def test_host_client_socket_pass_event_ok(socketio_test_client, mocker):
     socketio_test_client_under_test.connect(namespace="/host_client_socket")
     socketio_test_client_under_test.emit(namespace="/host_client_socket", event="pass")
     assert len(mock_socketio_emit.mock_calls) == 4
+
+
+def test_host_client_socket_picture_event_ok(socketio_test_client, mocker):
+    mock_socketio_emit = mocker.patch("qwazzock.server.SocketIO.emit")
+    game = Game()
+    game.question_type = "foo"
+    game.selected_image_index = 0
+    socketio_test_client_under_test = socketio_test_client(game)
+    socketio_test_client_under_test.connect(namespace="/host_client_socket")
+    socketio_test_client_under_test.emit(
+        namespace="/host_client_socket", event="picture"
+    )
+    assert game.question_type == "picture"
+
+
+def test_host_client_socket_picture_event_no_images(socketio_test_client, mocker):
+    mock_socketio_emit = mocker.patch("qwazzock.server.SocketIO.emit")
+    game = Game()
+    game.question_type = "foo"
+    game.selected_image_index = None
+    socketio_test_client_under_test = socketio_test_client(game)
+    socketio_test_client_under_test.connect(namespace="/host_client_socket")
+    socketio_test_client_under_test.emit(
+        namespace="/host_client_socket", event="picture"
+    )
+    assert game.question_type == "foo"
 
 
 def test_host_client_socket_reset_event_ok(socketio_test_client, mocker):
@@ -85,6 +121,19 @@ def test_host_client_socket_right_event_ok(socketio_test_client, mocker):
         "right", {"score_value": 1}, namespace="/host_client_socket"
     )
     assert len(mock_socketio_emit.mock_calls) == 4
+
+
+def test_host_client_socket_standard_event_ok(socketio_test_client, mocker):
+    mock_socketio_emit = mocker.patch("qwazzock.server.SocketIO.emit")
+    game = Game()
+    game.question_type = "foo"
+    game.selected_image_index = 0
+    socketio_test_client_under_test = socketio_test_client(game)
+    socketio_test_client_under_test.connect(namespace="/host_client_socket")
+    socketio_test_client_under_test.emit(
+        namespace="/host_client_socket", event="standard"
+    )
+    assert game.question_type == "standard"
 
 
 def test_host_client_socket_wrong_event_ok(socketio_test_client, mocker):


### PR DESCRIPTION
- Adds concept of `question type`. Existing game behaviour uses `standard` question type.
- New `picture` question type is used to provide players with image based questions.
- Question images replace buzzer image when under picture round.
- Images are made available to the game engine by storing them in a folder called `questions` within a content directory.
- Content directory is configured by supplying a `QWAZZOCK_CONTENT_PATH` env var.
- Picture round cannot be selected if there no content path has been provided, or there are no files in the questions folder.
- Question type reverts to `standard` automatically when there are no more images.
- Order of the question images is randomised when the game begins or is reset.
- Name of question image file is presented to the host, and acts as a prompt for what the answer is.