### PR TITLE
Publish python artefacts to PyPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ release: build
 	git update-index --refresh 
 	git diff-index --quiet HEAD --
 	git tag --sign --message "qwazzock version ${version}" ${version} && git push --tags
+	poetry publish
 
 .PHONY: run
 run:

--- a/README.md
+++ b/README.md
@@ -98,7 +98,12 @@ This includes:
 
 ### Release version
 
-Local repo must be clean.
+Tag the repository with the project version and publish the distributables to [PyPI](https://pypi.org/project/qwazzock/).
 
-`make release`
+*Local repo must be clean.*
+
+```
+poetry config pypi-token.pypi ${your-pypi-token}
+make release
+```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [tool.poetry]
 name = "qwazzock"
-version = "0.11.0"
-description = "Qwazzock quiz app."
-authors = ["Dave Randall <19395688+daveygit2050@users.noreply.github.com>"]
+version = "0.11.2"
+description = "An app for hosting interactive quizzes."
+authors = ["Dave Randall <19395688+daveygit2050@users.noreply.github.com>", "Iain Rawson <30925288+iainrawson@users.noreply.github.com>"]
+readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
- Adds `poetry publish` to `make release`.
- Updates README.md with how to authenticate.
- Sets readme in `pyproject.toml` so PyPI package description matches readme.
- Updates authors.