### PR TITLE
Allow host to arbitrarily lock teams out

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ As a host, you can then navigate to the `/host` path (e.g. http://127.0.0.1:5000
 
 You can also use `reset` to wipe all data for the in progress game and start a new one.
 
+Clicking on the team's button will lock out that team until the end of the round. This can be useful for managing elimitator rounds and the like.
+
 ### Question Types
 
 There are two "question types" you can select, `standard` or `picture`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qwazzock"
-version = "0.11.2"
+version = "0.12.0"
 description = "An app for hosting interactive quizzes."
 authors = ["Dave Randall <19395688+daveygit2050@users.noreply.github.com>", "Iain Rawson <30925288+iainrawson@users.noreply.github.com>"]
 readme = "README.md"

--- a/qwazzock/server.py
+++ b/qwazzock/server.py
@@ -71,6 +71,13 @@ def get_socketio_and_app(game):
         game.question_type = "standard"
         update_clients()
 
+    @socketio.on("team", namespace="/host_client_socket")
+    def host_client_socket_team_event(json):
+        team_name = json["team_name"]
+        logger.info(f"Received team event with team_name {team_name}.")
+        game.locked_out_teams.append(team_name)
+        update_clients()
+
     @socketio.on("wrong", namespace="/host_client_socket")
     def host_client_socket_wrong_event(json):
         wrong_answer_penalty = int(json["wrong_answer_penalty"])

--- a/qwazzock/static/js/host_client.js
+++ b/qwazzock/static/js/host_client.js
@@ -12,8 +12,17 @@ $(document).ready(function () {
     socket.on('host_client_data', function (msg) {
         $('#player').html("Player in hotseat: " + msg.player_in_hotseat);
         $('#team').html("Team in hotseat: " + msg.team_in_hotseat);
-        $('#locked_out').html("Locked out: " + msg.locked_out_teams);
-        $('#scores').html("Scores: " + JSON.stringify(msg.scores));
+        $('#teams').html("Teams: ");
+        $.each(msg.scores, function (team_name, team_score) {
+            var state = "enabled";
+            if (jQuery.inArray(team_name, msg.locked_out_teams) !== -1){
+                state = "disabled";
+            };
+            $('#teams').append(`<button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent" id="team-${team_name}" style="height:5vh;margin-right:1vw;" ${state}>${team_name} (${team_score})</button>`);
+            $(`#team-${team_name}`).click(function () {
+                socket.emit('team', { team_name: team_name });
+            });
+        });
         if (msg.player_in_hotseat == "Pending") {
             $("#right").prop("disabled", true);
             $("#wrong").prop("disabled", true);

--- a/qwazzock/templates/host_client.html
+++ b/qwazzock/templates/host_client.html
@@ -6,8 +6,7 @@
         <div id="player">Player in hotseat: Pending</div>
     </h1>
     <h2>
-        <div id="locked_out">Locked out: </div>
-        <div id="scores">Scores: {}</div>
+        <div id="teams">Teams: </div>
         <div id="answer"></div>
     </h2>
     <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -136,6 +136,18 @@ def test_host_client_socket_standard_event_ok(socketio_test_client, mocker):
     assert game.question_type == "standard"
 
 
+def test_host_client_socket_team_event_ok(socketio_test_client, mocker):
+    mock_socketio_emit = mocker.patch("qwazzock.server.SocketIO.emit")
+    game = Game()
+    game.locked_out_teams = []
+    socketio_test_client_under_test = socketio_test_client(game)
+    socketio_test_client_under_test.connect(namespace="/host_client_socket")
+    socketio_test_client_under_test.emit(
+        "team", {"team_name": "Oxford"}, namespace="/host_client_socket"
+    )
+    assert game.locked_out_teams == ["Oxford"]
+
+
 def test_host_client_socket_wrong_event_ok(socketio_test_client, mocker):
     mock_socketio_emit = mocker.patch("qwazzock.server.SocketIO.emit")
     game = Game()


### PR DESCRIPTION
- Replaces locked out teams and scores fields on the host client page with a unified teams field.
- Each team gets a button which includes their name and score.
- Team button is disabled if the team is locked out.
- If the host clicks on an enabled team button, that team is locked out.